### PR TITLE
Remove Zod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,7 @@
         "turbo": "^1.12.5",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.3.0",
-        "vitest": "^1.3.1",
-        "zod": "^3.22.4"
+        "vitest": "^1.3.1"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "^4.29.1"

--- a/package.json
+++ b/package.json
@@ -32,8 +32,7 @@
     "turbo": "^1.12.5",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vitest": "^1.3.1",
-    "zod": "^3.22.4"
+    "vitest": "^1.3.1"
   },
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.29.1"
@@ -43,5 +42,6 @@
       "eslint --fix",
       "prettier --write"
     ]
-  }
+  },
+  "packageManager": "npm@10.9.0"
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,13 +1,10 @@
-import { z } from "zod";
+export type TrackingEvent = {
+  id: string;
+  type: string;
+  timestamp: number;
+  context: Record<string, unknown>;
+};
 
-export const TrackingEventSchema = z.object({
-  id: z.string(),
-  type: z.string(),
-  timestamp: z.number(),
-  context: z.record(z.unknown()),
-});
-
-export type TrackingEvent = z.infer<typeof TrackingEventSchema>;
 export type BatchSize = number | "disabled";
 
 export type EventMiddleware = (


### PR DESCRIPTION
Zod was not used in many places, and it had almost no added value for us. So, we're going to remove it for now since it was about 80% of the core's bundle size.